### PR TITLE
kaolin 0.16.0

### DIFF
--- a/recipe/0001-loosen-version-pins.patch
+++ b/recipe/0001-loosen-version-pins.patch
@@ -1,4 +1,4 @@
-From 96d95828af5e8abcb8079246ad49ffa82e40f0a7 Mon Sep 17 00:00:00 2001
+From b4292355fdb268791860729bfdcefe0093bacc5f Mon Sep 17 00:00:00 2001
 From: Ista Zahn <istazahn@gmail.com>
 Date: Sun, 17 Oct 2021 14:20:08 -0400
 Subject: [PATCH] loosen version pins
@@ -8,9 +8,9 @@ Subject: [PATCH] loosen version pins
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/tools/build_requirements.txt b/tools/build_requirements.txt
-index 8c1c490..ca6e395 100644
+index 075aa61..d337cfe 100644
 --- a/tools/build_requirements.txt
 +++ b/tools/build_requirements.txt
 @@ -1 +1 @@
--cython==0.29.20
-+cython>=0.29.20
+-cython==0.29.37
++cython>=0.29.37

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,7 @@ requirements:
   host:
     - python
     - pip
-    # still using removed `from pkg_resources import packaging`
-    - setuptools <70
+    - setuptools
     - cython
     - numpy
     - pytorch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,7 @@ requirements:
     {% endif %}
   run:
     - python
+    - ipyevents
     - scipy
     - pillow
     - tqdm

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.15.0" %}
+{% set version = "0.16.0" %}
 
 {% if cuda_compiler_version in (None, "None", True, False) %}
 {% set cuda_major = 0 %}
@@ -12,12 +12,12 @@ package:
 
 source:
   url: https://github.com/NVIDIAGameWorks/kaolin/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: be1c02da148a79a5c02631d7eb30c080c079c7ea925fa89f7c4d2f24dbdfc03d
+  sha256: 08bc6b48a6e33a1628b66a87533ce0baf93d541fd8a0f2bbdb33489e193bca2a
   patches:
     - 0001-loosen-version-pins.patch
 
 build:
-  number: 3
+  number: 0
   skip: true  # [cuda_compiler_version == "None"]
   skip: true  # [win]
 requirements:


### PR DESCRIPTION
Update the version to 0.16.0, which doesn't require additional dependency (warp) that is not currently available in conda-forge yet (see https://github.com/conda-forge/kaolin-feedstock/pull/31)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
